### PR TITLE
Tree Hollows expanded

### DIFF
--- a/PrimitiveSurvival/PrimitiveSurvival/ModSystem/PrimitiveSurvivalSystem.cs
+++ b/PrimitiveSurvival/PrimitiveSurvival/ModSystem/PrimitiveSurvivalSystem.cs
@@ -63,6 +63,7 @@ namespace PrimitiveSurvival.ModSystem
             this.capi.RegisterEntityRendererClass("entitygenericshaperenderer", typeof(EntityGenericShapeRenderer));
             this.vrenderer = new VenomOverlayRenderer(api);
             api.Event.RegisterRenderer(this.vrenderer, EnumRenderStage.Ortho);
+            (capi.World as ClientMain).RegisterDialog(new GuiDialogHollowTransform(capi));
         }
 
 
@@ -118,6 +119,8 @@ namespace PrimitiveSurvival.ModSystem
 
             AiTaskRegistry.Register("meleeattackvenomous", typeof(AiTaskMeleeAttackVenomous));
             AiTaskRegistry.Register("meleeattackcrab", typeof(AiTaskMeleeAttackCrab));
+
+            api.RegisterCollectibleBehaviorClass("inTreeHollowTransform", typeof(BehaviorInTreeHollowTransform));
 
             api.RegisterBlockBehaviorClass("RightClickPickupSpawnWorm", typeof(RightClickPickupSpawnWorm));
             api.RegisterBlockBehaviorClass("RightClickPickupRaft", typeof(RightClickPickupRaft));

--- a/PrimitiveSurvival/PrimitiveSurvival/ModSystem/PrimitiveSurvivalSystem.cs
+++ b/PrimitiveSurvival/PrimitiveSurvival/ModSystem/PrimitiveSurvivalSystem.cs
@@ -227,15 +227,6 @@ namespace PrimitiveSurvival.ModSystem
             this.RegisterClasses(api);
         }
 
-        public static bool wildCraftTreesExists(ICoreServerAPI sapi)
-        {
-            //for adding tree hollow support
-            var wctrees = sapi?.ModLoader?.GetMod("wildcrafttrees");
-            if (wctrees != null)
-            { return true; }
-            return false;
-        }
-
         private void OnSaveGameLoading()
         {
             fishingChunks = new Dictionary<IServerChunk, int>();

--- a/PrimitiveSurvival/PrimitiveSurvival/ModSystem/blockentity/betreehollowgrown.cs
+++ b/PrimitiveSurvival/PrimitiveSurvival/ModSystem/blockentity/betreehollowgrown.cs
@@ -91,10 +91,8 @@ namespace PrimitiveSurvival.ModSystem
 
                 if (updatingInHours < 0)
                 {
-                    var block = this.Api.World.BlockAccessor.GetBlock(this.Pos, BlockLayersAccess.Default) as BlockTreeHollowGrown;
-
                     var uf = new TreeHollows();
-                    uf.AddItemStacks(this, uf.MakeItemStacks(block.FirstCodePart(1), this.Api as ICoreServerAPI));
+                    uf.AddItemStacks(this, uf.MakeItemStacks(this.Block, this.Api as ICoreServerAPI));
                     this.MarkDirty();
                 }
             }

--- a/PrimitiveSurvival/PrimitiveSurvival/ModSystem/blockentity/betreehollowgrown.cs
+++ b/PrimitiveSurvival/PrimitiveSurvival/ModSystem/blockentity/betreehollowgrown.cs
@@ -190,6 +190,17 @@ namespace PrimitiveSurvival.ModSystem
             return slot;
         }
 
+        internal CollectibleObject GetDisplayedCollectible()
+        {
+            var index = this.LastFilledSlot();
+            if (index < 0)
+            {
+                return null;
+            }
+
+            return this.inventory[index].Itemstack.Collectible;
+        }
+
         /*
         //private bool TryPut(ItemSlot slot, BlockSelection blockSel)
         private bool TryPut()
@@ -333,6 +344,10 @@ namespace PrimitiveSurvival.ModSystem
                         { mesh.Translate(new Vec3f(0f, 0.03f, 0f)); }
                         else //up has thicker bottom
                         { mesh.Translate(new Vec3f(0f, 0.23f, 0f)); }
+                        if (stack.Collectible.GetBehavior<BehaviorInTreeHollowTransform>()?.Transform is ModelTransform transform)
+                        {
+                            mesh.ModelTransform(transform);
+                        }
                         if (block.LastCodePart() == "north" || block.LastCodePart() == "south")
                         {
                             mesh.Rotate(new Vec3f(0.5f, 0, 0.5f), 0, 90, 0);

--- a/PrimitiveSurvival/PrimitiveSurvival/ModSystem/collectiblebehavior/behaviorintreehollowtransform.cs
+++ b/PrimitiveSurvival/PrimitiveSurvival/ModSystem/collectiblebehavior/behaviorintreehollowtransform.cs
@@ -1,0 +1,21 @@
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+
+namespace PrimitiveSurvival.ModSystem
+{
+    public class BehaviorInTreeHollowTransform : CollectibleBehavior
+    {
+        public ModelTransform Transform { get; set; } = ModelTransform.NoTransform;
+
+        public BehaviorInTreeHollowTransform(CollectibleObject collectibleObject) : base(collectibleObject) { }
+
+        public override void Initialize(JsonObject properties)
+        {
+            base.Initialize(properties);
+            if (properties.AsObject<ModelTransform>() is ModelTransform transform)
+            {
+                this.Transform = transform;
+            }
+        }
+    }
+}

--- a/PrimitiveSurvival/PrimitiveSurvival/ModSystem/gui/hollowTransformGui.cs
+++ b/PrimitiveSurvival/PrimitiveSurvival/ModSystem/gui/hollowTransformGui.cs
@@ -1,0 +1,308 @@
+namespace PrimitiveSurvival.ModSystem
+{
+    using System;
+    using System.Text;
+    using Vintagestory.API.Client;
+    using Vintagestory.API.Common;
+    using Vintagestory.API.Config;
+    using Vintagestory.API.Datastructures;
+    using Vintagestory.API.MathTools;
+    using Vintagestory.API.Server;
+    using Vintagestory.API.Util;
+    using Vintagestory.Client;
+
+    public class GuiDialogHollowTransform : GuiDialog
+    {
+        private ModelTransform originalTransform;
+
+        private CollectibleObject oldCollectible;
+
+        private BlockPos oldPos;
+
+        private ModelTransform currentTransform = new ModelTransform();
+
+        private ModelTransform TargetTransform
+        {
+            get => this.oldCollectible.GetBehavior<BehaviorInTreeHollowTransform>()?.Transform ?? ModelTransform.NoTransform;
+            set
+            {
+                if (!this.oldCollectible.HasBehavior<BehaviorInTreeHollowTransform>())
+                {
+                    this.oldCollectible.CollectibleBehaviors = this.oldCollectible.CollectibleBehaviors.Append(new BehaviorInTreeHollowTransform(this.oldCollectible));
+                }
+                this.oldCollectible.GetBehavior<BehaviorInTreeHollowTransform>().Transform = value;
+            }
+        }
+
+        public override string ToggleKeyCombinationCode => null;
+
+        public override bool PrefersUngrabbedMouse => true;
+
+        public GuiDialogHollowTransform(ICoreClientAPI capi) : base(capi)
+        {
+            this.capi = capi;
+            capi.ChatCommands.Create("hollowTfEdit")
+                .WithDescription("Edit the model transform for the item displayed in the currently targeted Tree Hollow.")
+                .HandleWith(this.OnCommandTransformEditor)
+                .RequiresPrivilege(Privilege.useblock)
+                .Validate();
+        }
+
+        private TextCommandResult OnCommandTransformEditor(TextCommandCallingArgs args)
+        {
+            if (this.capi.World.Player.CurrentBlockSelection?.Position is BlockPos blockPos
+                && this.capi.World.BlockAccessor.GetBlockEntity(blockPos) is BETreeHollowGrown treeHollowGrown
+                && treeHollowGrown.GetDisplayedCollectible() is CollectibleObject collectible)
+            {
+                this.currentTransform = new ModelTransform
+                {
+                    Rotation = new Vec3f(),
+                    Translation = new Vec3f()
+                };
+                this.oldCollectible = collectible;
+                this.oldPos = blockPos;
+                this.originalTransform = this.TargetTransform;
+                this.TargetTransform = this.currentTransform = this.originalTransform.Clone();
+                this.TryOpen();
+                return TextCommandResult.Success("Opened Tree Hollow Transform dialog.");
+            }
+            return TextCommandResult.Error("Must be targeting a Tree Hollow that contains an item to use that command.");
+        }
+
+        public override void OnGuiOpened()
+        {
+            this.ComposeDialog();
+        }
+
+        private void ComposeDialog()
+        {
+            this.ClearComposers();
+            var line = ElementBounds.Fixed(0.0, 22.0, 500.0, 20.0);
+            var inputBnds = ElementBounds.Fixed(0.0, 11.0, 230.0, 30.0);
+            var bgBounds = ElementBounds.Fill.WithFixedPadding(GuiStyle.ElementToDialogPadding);
+            bgBounds.BothSizing = ElementSizing.FitToChildren;
+            var dialogBounds = ElementStdBounds.AutosizedMainDialog.WithAlignment(EnumDialogArea.LeftTop).WithFixedAlignmentOffset(110.0 + GuiStyle.DialogToScreenPadding, GuiStyle.DialogToScreenPadding);
+            var textAreaBounds = ElementBounds.FixedSize(500.0, 200.0);
+            var clippingBounds = ElementBounds.FixedSize(500.0, 200.0);
+            var btnBounds = ElementBounds.FixedSize(200.0, 20.0).WithAlignment(EnumDialogArea.LeftFixed).WithFixedPadding(10.0, 2.0);
+
+            this.SingleComposer = this.capi.Gui.CreateCompo("transformeditor", dialogBounds).AddShadedDialogBG(bgBounds).AddDialogTitleBar("Transform Editor (Tree Hollows)", OnTitleBarClose)
+                .BeginChildElements(bgBounds)
+                .AddStaticText("Translation X", CairoFont.WhiteDetailText(), line = line.FlatCopy().WithFixedWidth(230.0))
+                .AddNumberInput(inputBnds = inputBnds.BelowCopy(), this.OnTranslateX, CairoFont.WhiteDetailText(), "translatex")
+                .AddStaticText("Origin X", CairoFont.WhiteDetailText(), line.RightCopy(40.0))
+                .AddNumberInput(inputBnds.RightCopy(40.0), this.OnOriginX, CairoFont.WhiteDetailText(), "originx")
+                .AddStaticText("Translation Y", CairoFont.WhiteDetailText(), line = line.BelowCopy(0.0, 33.0))
+                .AddNumberInput(inputBnds = inputBnds.BelowCopy(0.0, 22.0), this.OnTranslateY, CairoFont.WhiteDetailText(), "translatey")
+                .AddStaticText("Origin Y", CairoFont.WhiteDetailText(), line.RightCopy(40.0))
+                .AddNumberInput(inputBnds.RightCopy(40.0), this.OnOriginY, CairoFont.WhiteDetailText(), "originy")
+                .AddStaticText("Translation Z", CairoFont.WhiteDetailText(), line = line.BelowCopy(0.0, 32.0))
+                .AddNumberInput(inputBnds = inputBnds.BelowCopy(0.0, 22.0), this.OnTranslateZ, CairoFont.WhiteDetailText(), "translatez")
+                .AddStaticText("Origin Z", CairoFont.WhiteDetailText(), line.RightCopy(40.0))
+                .AddNumberInput(inputBnds.RightCopy(40.0), this.OnOriginZ, CairoFont.WhiteDetailText(), "originz")
+                .AddStaticText("Rotation X", CairoFont.WhiteDetailText(), line = line.BelowCopy(0.0, 33.0).WithFixedWidth(500.0))
+                .AddSlider(this.OnRotateX, inputBnds = inputBnds.BelowCopy(0.0, 22.0).WithFixedWidth(500.0), "rotatex")
+                .AddStaticText("Rotation Y", CairoFont.WhiteDetailText(), line = line.BelowCopy(0.0, 32.0))
+                .AddSlider(this.OnRotateY, inputBnds = inputBnds.BelowCopy(0.0, 22.0), "rotatey")
+                .AddStaticText("Rotation Z", CairoFont.WhiteDetailText(), line = line.BelowCopy(0.0, 32.0))
+                .AddSlider(this.OnRotateZ, inputBnds = inputBnds.BelowCopy(0.0, 22.0), "rotatez")
+                .AddStaticText("Scale", CairoFont.WhiteDetailText(), line = line.BelowCopy(0.0, 32.0))
+                .AddSlider(this.OnScale, inputBnds = inputBnds.BelowCopy(0.0, 22.0), "scale")
+                .AddSwitch(this.onFlipXAxis, inputBnds = inputBnds.BelowCopy(0.0, 10.0), "flipx", 20.0)
+                .AddStaticText("Flip on X-Axis", CairoFont.WhiteDetailText(), inputBnds.RightCopy(10.0, 1.0).WithFixedWidth(200.0))
+                .AddStaticText("Json Code (added as a behavior to the collectible)", CairoFont.WhiteDetailText(), line = line.BelowCopy(0.0, 72.0))
+                .BeginClip(clippingBounds.FixedUnder(inputBnds, 37.0))
+                .AddTextArea(textAreaBounds, null, CairoFont.WhiteSmallText(), "textarea")
+                .EndClip()
+                .AddSmallButton("Close & Apply", this.OnApplyJson, btnBounds = btnBounds.FlatCopy().FixedUnder(clippingBounds, 15.0))
+                .AddSmallButton("Copy JSON", this.OnCopyJson, btnBounds = btnBounds.FlatCopy().WithAlignment(EnumDialogArea.RightFixed).WithFixedPadding(10.0, 2.0))
+                .EndChildElements()
+                .Compose();
+            this.SingleComposer.GetTextInput("translatex").SetValue(this.currentTransform.Translation.X.ToString(GlobalConstants.DefaultCultureInfo));
+            this.SingleComposer.GetTextInput("translatey").SetValue(this.currentTransform.Translation.Y.ToString(GlobalConstants.DefaultCultureInfo));
+            this.SingleComposer.GetTextInput("translatez").SetValue(this.currentTransform.Translation.Z.ToString(GlobalConstants.DefaultCultureInfo));
+            this.SingleComposer.GetTextInput("originx").SetValue(this.currentTransform.Origin.X.ToString(GlobalConstants.DefaultCultureInfo));
+            this.SingleComposer.GetTextInput("originy").SetValue(this.currentTransform.Origin.Y.ToString(GlobalConstants.DefaultCultureInfo));
+            this.SingleComposer.GetTextInput("originz").SetValue(this.currentTransform.Origin.Z.ToString(GlobalConstants.DefaultCultureInfo));
+            this.SingleComposer.GetSlider("rotatex").SetValues((int)this.currentTransform.Rotation.X, -180, 180, 1);
+            this.SingleComposer.GetSlider("rotatey").SetValues((int)this.currentTransform.Rotation.Y, -180, 180, 1);
+            this.SingleComposer.GetSlider("rotatez").SetValues((int)this.currentTransform.Rotation.Z, -180, 180, 1);
+            this.SingleComposer.GetSlider("scale").SetValues((int)Math.Abs(100f * this.currentTransform.ScaleXYZ.X), 25, 600, 1);
+            this.SingleComposer.GetSwitch("flipx").On = this.currentTransform.ScaleXYZ.X < 0f;
+        }
+
+        private void onFlipXAxis(bool on)
+        {
+            this.currentTransform.ScaleXYZ.X *= -1f;
+            this.updateJson();
+        }
+
+        private void OnOriginX(string val)
+        {
+            this.currentTransform.Origin.X = val.ToFloat();
+            this.updateJson();
+        }
+
+        private void OnOriginY(string val)
+        {
+            this.currentTransform.Origin.Y = val.ToFloat();
+            this.updateJson();
+        }
+
+        private void OnOriginZ(string val)
+        {
+            this.currentTransform.Origin.Z = val.ToFloat();
+            this.updateJson();
+        }
+
+        private bool OnApplyJson()
+        {
+            this.TargetTransform = this.originalTransform = this.currentTransform;
+            this.currentTransform = null;
+            this.TryClose();
+            return true;
+        }
+
+        private bool OnCopyJson()
+        {
+            ScreenManager.Platform.XPlatInterface.SetClipboardText(this.getJson());
+            return true;
+        }
+
+        private void updateJson()
+        {
+            this.SingleComposer.GetTextArea("textarea").SetValue(this.getJson());
+            this.capi.World.BlockAccessor.MarkBlockDirty(this.oldPos);
+        }
+
+        private string getJson()
+        {
+            var json = new StringBuilder();
+            var def = ModelTransform.NoTransform;
+            var indent = "\t";
+            json.Append("{\n");
+            json.Append(indent + "\"name\": \"intreeHollowTransform\",\n");
+            json.Append(indent + "\"properties\":\n");
+            json.Append(indent + "{\n");
+            indent = "\t\t";
+            var added = false;
+            if (this.currentTransform.Translation.X != def.Translation.X || this.currentTransform.Translation.Y != def.Translation.Y || this.currentTransform.Translation.Z != def.Translation.Z)
+            {
+                json.Append(string.Format(GlobalConstants.DefaultCultureInfo, indent + "translation: {{ x: {0}, y: {1}, z: {2} }}", this.currentTransform.Translation.X, this.currentTransform.Translation.Y, this.currentTransform.Translation.Z));
+                added = true;
+            }
+            if (this.currentTransform.Rotation.X != def.Rotation.X || this.currentTransform.Rotation.Y != def.Rotation.Y || this.currentTransform.Rotation.Z != def.Rotation.Z)
+            {
+                if (added)
+                {
+                    json.Append(",\n");
+                }
+                json.Append(string.Format(GlobalConstants.DefaultCultureInfo, indent + "rotation: {{ x: {0}, y: {1}, z: {2} }}", this.currentTransform.Rotation.X, this.currentTransform.Rotation.Y, this.currentTransform.Rotation.Z));
+                added = true;
+            }
+            if (this.currentTransform.Origin.X != def.Origin.X || this.currentTransform.Origin.Y != def.Origin.Y || this.currentTransform.Origin.Z != def.Origin.Z)
+            {
+                if (added)
+                {
+                    json.Append(",\n");
+                }
+                json.Append(string.Format(GlobalConstants.DefaultCultureInfo, indent + "origin: {{ x: {0}, y: {1}, z: {2} }}", this.currentTransform.Origin.X, this.currentTransform.Origin.Y, this.currentTransform.Origin.Z));
+                added = true;
+            }
+            if (this.currentTransform.ScaleXYZ.X != def.ScaleXYZ.X)
+            {
+                if (added)
+                {
+                    json.Append(",\n");
+                }
+                if (this.currentTransform.ScaleXYZ.X != this.currentTransform.ScaleXYZ.Y || this.currentTransform.ScaleXYZ.X != this.currentTransform.ScaleXYZ.Z)
+                {
+                    json.Append(string.Format(GlobalConstants.DefaultCultureInfo, indent + "scaleXyz: {{ x: {0}, y: {1}, z: {2} }}", this.currentTransform.ScaleXYZ.X, this.currentTransform.ScaleXYZ.Y, this.currentTransform.ScaleXYZ.Z));
+                }
+                else
+                {
+                    json.Append(string.Format(GlobalConstants.DefaultCultureInfo, indent + "scale: {0}", this.currentTransform.ScaleXYZ.X));
+                }
+            }
+            indent = "\t";
+            json.Append("\n");
+            json.Append(indent + "}\n");
+            json.Append("}");
+            var jsonstr = json.ToString();
+            var tree = new TreeAttribute();
+            tree.SetString("json", jsonstr);
+            return tree.GetString("json");
+        }
+
+        private bool OnScale(int val)
+        {
+            this.currentTransform.Scale = val / 100f;
+            if (this.SingleComposer.GetSwitch("flipx").On)
+            {
+                this.currentTransform.ScaleXYZ.X *= -1f;
+            }
+            this.updateJson();
+            return true;
+        }
+
+        private bool OnRotateX(int deg)
+        {
+            this.currentTransform.Rotation.X = deg;
+            this.updateJson();
+            return true;
+        }
+
+        private bool OnRotateY(int deg)
+        {
+            this.currentTransform.Rotation.Y = deg;
+            this.updateJson();
+            return true;
+        }
+
+        private bool OnRotateZ(int deg)
+        {
+            this.currentTransform.Rotation.Z = deg;
+            this.updateJson();
+            return true;
+        }
+
+        private void OnTranslateX(string val)
+        {
+            this.currentTransform.Translation.X = val.ToFloat();
+            this.updateJson();
+        }
+
+        private void OnTranslateY(string val)
+        {
+            this.currentTransform.Translation.Y = val.ToFloat();
+            this.updateJson();
+        }
+
+        private void OnTranslateZ(string val)
+        {
+            this.currentTransform.Translation.Z = val.ToFloat();
+            this.updateJson();
+        }
+
+        private void OnTitleBarClose()
+        {
+            this.TryClose();
+        }
+
+        public override void OnGuiClosed()
+        {
+            base.OnGuiClosed();
+            if (this.oldCollectible != null)
+            {
+                this.TargetTransform = this.originalTransform;
+            }
+            this.capi.World.BlockAccessor.MarkBlockDirty(this.oldPos);
+        }
+
+        public override void OnMouseWheel(MouseWheelEventArgs args)
+        {
+            base.OnMouseWheel(args);
+            args.SetHandled();
+        }
+    }
+}

--- a/PrimitiveSurvival/PrimitiveSurvival/ModSystem/worldgen/treehollows.cs
+++ b/PrimitiveSurvival/PrimitiveSurvival/ModSystem/worldgen/treehollows.cs
@@ -217,7 +217,7 @@ namespace PrimitiveSurvival.ModSystem
                         {
                             var hollow = blockAccessor.GetBlockEntity(pos) as BETreeHollowGrown;
                             //hollow.Initialize(this.sapi); //SpawnBlockEntity does this already
-                            var makeStacks = this.MakeItemStacks(hollowType, this.sapi);
+                            var makeStacks = this.MakeItemStacks(block, this.sapi);
                             if (makeStacks != null)
                             { this.AddItemStacks(hollow, makeStacks); }
                         }
@@ -236,9 +236,9 @@ namespace PrimitiveSurvival.ModSystem
         }
 
         // Makes a list of random ItemStacks to be placed inside our tree hollow
-        public IEnumerable<ItemStack> MakeItemStacks(string hollowType, ICoreServerAPI sapi)
+        public IEnumerable<ItemStack> MakeItemStacks(Block block, ICoreServerAPI sapi)
         {
-            var shuffleBag = this.MakeShuffleBag(hollowType, sapi);
+            var shuffleBag = this.MakeShuffleBag(block, sapi);
             var itemStacks = new Dictionary<string, ItemStack>();
             var minDrops = MinItems;
             if (ModConfig.Loaded.TreeHollowsMaxItems < MinItems)
@@ -289,86 +289,34 @@ namespace PrimitiveSurvival.ModSystem
         }
 
         // Creates our ShuffleBag to pick from when generating items for the tree hollow
-        private ShuffleBag<string> MakeShuffleBag(string hollowType, ICoreServerAPI sapi)
+        private ShuffleBag<string> MakeShuffleBag(Block block, ICoreServerAPI sapi)
         {
             var shuffleBag = new ShuffleBag<string>(100, sapi.World.Rand);
-            if (hollowType.Contains("base"))
+
+            if (block == null)
+            { return shuffleBag; }
+
+            var psAttributes = block.Attributes["primitivesurvival"];
+            var hollowType = psAttributes["treeHollowType"].AsString("all");
+            var contentsByHollowType = psAttributes["treeHollowContentsByHollowType"];
+
+            if (hollowType != "all")
             {
-
-                shuffleBag.Add("primitivesurvival:item-earthworm", 6);
-                shuffleBag.Add("primitivesurvival:item-earthworm", 6);
-                shuffleBag.Add("primitivesurvival:item-earthworm", 6);
-                shuffleBag.Add("primitivesurvival:item-earthwormcastings", 6);
-                shuffleBag.Add("primitivesurvival:item-earthwormcastings", 6);
-                //shuffleBag.Add("primitivesurvival:item-snake-blackrat", 1);
-                //shuffleBag.Add("primitivesurvival:item-snake-pitviper", 1);
-                //shuffleBag.Add("primitivesurvival:item-snake-coachwhip", 1);
-
-                // 1.16
-                // shuffleBag.Add("block-mushroom-bolete-normal-free", 3);
-                // shuffleBag.Add("block-mushroom-fieldmushroom-normal-free", 5);
-
-                shuffleBag.Add("block-mushroom-kingbolete-normal", 3);
-                shuffleBag.Add("block-mushroom-fieldmushroom-normal", 5);
+                AddItemsToShuffleBag(shuffleBag, contentsByHollowType[hollowType]);
             }
-            else
-            {
-                shuffleBag.Add("item-honeycomb", 3);
-                shuffleBag.Add("item-resin", 4);
-                shuffleBag.Add("item-stick", 4);
-                shuffleBag.Add("item-insect-grub", 3);
-                shuffleBag.Add("item-insect-termite", 3);
-            }
-            shuffleBag.Add("item-seeds-turnip", 3);
-            shuffleBag.Add("item-seeds-onion", 3);
-            shuffleBag.Add("item-seeds-peanut", 3);
-            shuffleBag.Add("item-seeds-flax", 3);
-            shuffleBag.Add("item-seeds-spelt", 3);
-            shuffleBag.Add("item-seeds-pumpkin", 3);
-            shuffleBag.Add("item-seeds-pineapple", 3);
-            shuffleBag.Add("item-seeds-carrot", 3);
-            shuffleBag.Add("item-seeds-rice", 3);
-            shuffleBag.Add("item-seeds-rye", 3);
-            shuffleBag.Add("item-seeds-cabbage", 3);
-            shuffleBag.Add("item-seeds-cassava", 3);
-            shuffleBag.Add("item-seeds-amaranth", 3);
-            shuffleBag.Add("item-seeds-sunflower", 3);
+            AddItemsToShuffleBag(shuffleBag, contentsByHollowType["all"]);
 
-            shuffleBag.Add("item-treeseed-oak", 3);
-            shuffleBag.Add("item-treeseed-pine", 3);
-            shuffleBag.Add("item-treeseed-larch", 3);
-            shuffleBag.Add("item-treeseed-crimsonkingmaple", 3);
-            shuffleBag.Add("item-treeseed-redwood", 3);
-            shuffleBag.Add("item-treeseed-ebony", 3);
-            shuffleBag.Add("item-treeseed-acacia", 3);
-            shuffleBag.Add("item-treeseed-walnut", 3);
-            shuffleBag.Add("item-treeseed-baldcypress", 3);
-            shuffleBag.Add("item-treeseed-birch", 3);
-            shuffleBag.Add("item-treeseed-maple", 3);
-            shuffleBag.Add("item-treeseed-kapok", 3);
-
-            if (PrimitiveSurvivalSystem.wildCraftTreesExists(sapi))
-            {
-                shuffleBag.Add("item-treeseed-alder", 3);
-                //shuffleBag.Add("item-treeseed-bearnut", 3);
-                //shuffleBag.Add("item-treeseed-beech", 3);
-                shuffleBag.Add("item-treeseed-bluespruce", 3);
-                shuffleBag.Add("item-treeseed-blackpoplar", 3);
-                shuffleBag.Add("item-treeseed-brideinwhite", 3);
-                //shuffleBag.Add("item-treeseed-catalpa", 3);
-                shuffleBag.Add("item-treeseed-douglasfir", 3);
-                //shuffleBag.Add("item-treeseed-elm", 3);
-                //shuffleBag.Add("item-treeseed-eucalyptus", 3);
-                shuffleBag.Add("item-treeseed-honeylocust", 3);
-                //shuffleBag.Add("item-treeseed-mahogany", 3);
-                //shuffleBag.Add("item-treeseed-pyramidalpoplar", 3);
-                //shuffleBag.Add("item-treeseed-sal", 3);
-                shuffleBag.Add("item-treeseed-saxaul", 3);
-                shuffleBag.Add("item-treeseed-spruce", 3);
-                shuffleBag.Add("item-treeseed-sycamore", 3);
-                shuffleBag.Add("item-treeseed-willow", 3);
-            }
             return shuffleBag;
+        }
+
+        private void AddItemsToShuffleBag(ShuffleBag<string> shuffleBag, JsonObject attributesObjectArray)
+        {
+            foreach (var collectible in attributesObjectArray.AsArray())
+            {
+                if (!collectible["code"].Exists)
+                { continue; }
+                shuffleBag.Add(collectible["code"].AsString(), collectible["amount"].AsInt(1));
+            }
         }
     }
 }

--- a/PrimitiveSurvival/PrimitiveSurvival/ModSystem/worldgen/treehollows.cs
+++ b/PrimitiveSurvival/PrimitiveSurvival/ModSystem/worldgen/treehollows.cs
@@ -296,15 +296,18 @@ namespace PrimitiveSurvival.ModSystem
             if (block == null)
             { return shuffleBag; }
 
-            var psAttributes = block.Attributes["primitivesurvival"];
+            var psAttributes = block.Attributes?["primitivesurvival"];
+            if (psAttributes == null)
+            { return shuffleBag; }
+
             var hollowType = psAttributes["treeHollowType"].AsString("all");
             var contentsByHollowType = psAttributes["treeHollowContentsByHollowType"];
 
             if (hollowType != "all")
             {
-                AddItemsToShuffleBag(shuffleBag, contentsByHollowType[hollowType]);
+                this.AddItemsToShuffleBag(shuffleBag, contentsByHollowType[hollowType]);
             }
-            AddItemsToShuffleBag(shuffleBag, contentsByHollowType["all"]);
+            this.AddItemsToShuffleBag(shuffleBag, contentsByHollowType["all"]);
 
             return shuffleBag;
         }

--- a/PrimitiveSurvival/PrimitiveSurvival/assets/primitivesurvival/blocktypes/wood/treehollowgrown.json
+++ b/PrimitiveSurvival/PrimitiveSurvival/assets/primitivesurvival/blocktypes/wood/treehollowgrown.json
@@ -24,6 +24,67 @@
       "*-larch-*": 3,
       "*-walnut-*": 4,
       "*": 4
+    },
+    "primitivesurvival":
+    {
+      "treeHollowTypeByType":
+      {
+        "*-base-*": "base",
+        "*-base2-*": "base",
+        "*-up-*": "up",
+        "*-up2-*": "up"
+      },
+      "treeHollowContentsByHollowType":
+      {
+        "base":
+        [
+          { "code": "primitivesurvival:item-earthworm", "amount": 6 },
+          { "code": "primitivesurvival:item-earthworm", "amount": 6 },
+          { "code": "primitivesurvival:item-earthworm", "amount": 6 },
+          { "code": "primitivesurvival:item-earthwormcastings", "amount": 6 },
+          { "code": "primitivesurvival:item-earthwormcastings", "amount": 6 },
+          { "code": "block-mushroom-kingbolete-normal", "amount": 3 },
+          { "code": "block-mushroom-fieldmushroom-normal", "amount": 5 }
+        ],
+        "up":
+        [
+          { "code": "item-honeycomb", "amount": 3 },
+          { "code": "item-resin", "amount": 4 },
+          { "code": "item-stick", "amount": 4 },
+          { "code": "item-insect-grub", "amount": 3 },
+          { "code": "item-insect-termite", "amount": 3 }
+        ],
+        "all":
+        [
+          { "code": "item-seeds-turnip", "amount": 3 },
+          { "code": "item-seeds-onion", "amount": 3 },
+          { "code": "item-seeds-peanut", "amount": 3 },
+          { "code": "item-seeds-flax", "amount": 3 },
+          { "code": "item-seeds-spelt", "amount": 3 },
+          { "code": "item-seeds-pumpkin", "amount": 3 },
+          { "code": "item-seeds-pineapple", "amount": 3 },
+          { "code": "item-seeds-carrot", "amount": 3 },
+          { "code": "item-seeds-rice", "amount": 3 },
+          { "code": "item-seeds-rye", "amount": 3 },
+          { "code": "item-seeds-cabbage", "amount": 3 },
+          { "code": "item-seeds-cassava", "amount": 3 },
+          { "code": "item-seeds-amaranth", "amount": 3 },
+          { "code": "item-seeds-sunflower", "amount": 3 },
+
+          { "code": "item-treeseed-oak", "amount": 3 },
+          { "code": "item-treeseed-pine", "amount": 3 },
+          { "code": "item-treeseed-larch", "amount": 3 },
+          { "code": "item-treeseed-crimsonkingmaple", "amount": 3 },
+          { "code": "item-treeseed-redwood", "amount": 3 },
+          { "code": "item-treeseed-ebony", "amount": 3 },
+          { "code": "item-treeseed-acacia", "amount": 3 },
+          { "code": "item-treeseed-walnut", "amount": 3 },
+          { "code": "item-treeseed-baldcypress", "amount": 3 },
+          { "code": "item-treeseed-birch", "amount": 3 },
+          { "code": "item-treeseed-maple", "amount": 3 },
+          { "code": "item-treeseed-kapok", "amount": 3 }
+        ]
+      }
     }
   },
     "variantgroups": [

--- a/PrimitiveSurvival/PrimitiveSurvival/assets/primitivesurvival/patches/wildcrafttrees/ps-treehollowcontents.json
+++ b/PrimitiveSurvival/PrimitiveSurvival/assets/primitivesurvival/patches/wildcrafttrees/ps-treehollowcontents.json
@@ -1,0 +1,29 @@
+[
+  {
+    "file": "primitivesurvival:blocktypes/wood/treehollowgrown.json",
+    "side": "server",
+    "op": "addeach",
+    "path": "/attributes/primitivesurvival/treeHollowContentsByHollowType/all/-",
+    "value": [
+      { "code": "item-treeseed-alder", "amount": 3 },
+      //{ "code": "item-treeseed-bearnut", "amount": 3 },
+      //{ "code": "item-treeseed-beech", "amount": 3 },
+      { "code": "item-treeseed-bluespruce", "amount": 3 },
+      { "code": "item-treeseed-blackpoplar", "amount": 3 },
+      { "code": "item-treeseed-brideinwhite", "amount": 3 },
+      //{ "code": "item-treeseed-catalpa", "amount": 3 },
+      { "code": "item-treeseed-douglasfir", "amount": 3 },
+      //{ "code": "item-treeseed-elm", "amount": 3 },
+      //{ "code": "item-treeseed-eucalyptus", "amount": 3 },
+      { "code": "item-treeseed-honeylocust", "amount": 3 },
+      //{ "code": "item-treeseed-mahogany", "amount": 3 },
+      //{ "code": "item-treeseed-pyramidalpoplar", "amount": 3 },
+      //{ "code": "item-treeseed-sal", "amount": 3 },
+      { "code": "item-treeseed-saxaul", "amount": 3 },
+      { "code": "item-treeseed-spruce", "amount": 3 },
+      { "code": "item-treeseed-sycamore", "amount": 3 },
+      { "code": "item-treeseed-willow", "amount": 3 }
+    ],
+    "dependsOn": [ { "modid": "wildcrafttrees" } ]
+  }
+]


### PR DESCRIPTION
- Changes tree hollows to read from block definitions for contents instead of hard-coded values.
- Tree Hollows apply model transform defined in the displayed item's `inTreeHollowTransform` CollectibleBehavior
- Tree Hollow transform is editable in-world via the `.hollowtfedit` command while targeting a Tree Hollow with the desired item currently being displayed.